### PR TITLE
Make notes not requred when registering a property

### DIFF
--- a/lib/fruit_picker/accounts/property.ex
+++ b/lib/fruit_picker/accounts/property.ex
@@ -52,7 +52,6 @@ defmodule FruitPicker.Accounts.Property do
       :address_closest_intersection,
       :address_city,
       :address_postal_code,
-      :notes
     ])
     |> assoc_constraint(:person)
   end
@@ -77,7 +76,6 @@ defmodule FruitPicker.Accounts.Property do
       :address_closest_intersection,
       :address_city,
       :address_postal_code,
-      :notes
     ])
     |> assoc_constraint(:person)
   end


### PR DESCRIPTION
I found it very annoying that a notes field is required when you set up a property:
![CleanShot 2024-05-13 at 09 49 55@2x](https://github.com/nfftt/portal/assets/34720/470a5bc0-e2a4-4ae9-862e-c3e8c8bea234)
