### PR TITLE
Show number of picks in users page & add export

### DIFF
--- a/lib/fruit_picker/accounts.ex
+++ b/lib/fruit_picker/accounts.ex
@@ -46,51 +46,32 @@ defmodule FruitPicker.Accounts do
 
   """
   # Note the fact that we don't select all columns here may bite us in the ass later
+  @person_fields [
+    :id,
+    :email,
+    :first_name,
+    :last_name,
+    :role,
+    :membership_is_active,
+    :is_picker,
+    :is_lead_picker,
+    :is_tree_owner
+  ]
   def list_people do
     Person
-    |> select([
-      :id,
-      :email,
-      :first_name,
-      :last_name,
-      :role,
-      :membership_is_active,
-      :is_picker,
-      :is_lead_picker,
-      :is_tree_owner
-    ])
+    |> select(^@person_fields)
     |> Repo.all()
   end
 
   def list_people(page) do
     Person
-    |> select([
-      :id,
-      :email,
-      :first_name,
-      :last_name,
-      :role,
-      :membership_is_active,
-      :is_picker,
-      :is_lead_picker,
-      :is_tree_owner
-    ])
+    |> select(^@person_fields)
     |> Repo.paginate(page: page)
   end
 
   def list_people(page, sort_by, desc \\ false) do
     Person
-    |> select([
-      :id,
-      :email,
-      :first_name,
-      :last_name,
-      :role,
-      :membership_is_active,
-      :is_picker,
-      :is_lead_picker,
-      :is_tree_owner
-    ])
+    |> select(^@person_fields)
     |> sort_people_query(sort_by, desc)
     |> Repo.paginate(page: page)
   end
@@ -121,17 +102,7 @@ defmodule FruitPicker.Accounts do
       from(
         q in Person,
         where: q.role == "admin",
-        select: [
-          :id,
-          :email,
-          :first_name,
-          :last_name,
-          :role,
-          :membership_is_active,
-          :is_picker,
-          :is_lead_picker,
-          :is_tree_owner
-        ]
+        select: ^@person_fields
       )
     )
   end
@@ -141,17 +112,7 @@ defmodule FruitPicker.Accounts do
       from(
         q in Person,
         where: q.role == "agency",
-        select: [
-          :id,
-          :email,
-          :first_name,
-          :last_name,
-          :role,
-          :membership_is_active,
-          :is_picker,
-          :is_lead_picker,
-          :is_tree_owner
-        ]
+        select: ^@person_fields
       )
     )
   end
@@ -159,37 +120,18 @@ defmodule FruitPicker.Accounts do
   def list_agencies(page, sort_by, desc \\ false) do
     Person
     |> where([p], p.role == "agency")
-    |> select([
-      :id,
-      :email,
-      :first_name,
-      :last_name,
-      :role,
-      :membership_is_active,
-      :is_picker,
-      :is_lead_picker,
-      :is_tree_owner
-    ])
+    |> select(^@person_fields)
     |> sort_people_query(sort_by, desc)
     |> Repo.paginate(page: page)
   end
+
 
   def list_pickers do
     Repo.all(
       from(
         q in Person,
         where: q.is_picker == true,
-        select: [
-          :id,
-          :email,
-          :first_name,
-          :last_name,
-          :role,
-          :membership_is_active,
-          :is_picker,
-          :is_lead_picker,
-          :is_tree_owner
-        ]
+        select: ^@person_fields
       )
     )
   end
@@ -197,17 +139,7 @@ defmodule FruitPicker.Accounts do
   def list_pickers(page, sort_by, desc \\ false) do
     Person
     |> where([p], p.is_picker == true)
-    |> select([
-      :id,
-      :email,
-      :first_name,
-      :last_name,
-      :role,
-      :membership_is_active,
-      :is_picker,
-      :is_lead_picker,
-      :is_tree_owner
-    ])
+    |> select(^@person_fields)
     |> sort_people_query(sort_by, desc)
     |> Repo.paginate(page: page)
   end
@@ -236,17 +168,7 @@ defmodule FruitPicker.Accounts do
       from(
         q in Person,
         where: q.is_lead_picker == true,
-        select: [
-          :id,
-          :email,
-          :first_name,
-          :last_name,
-          :role,
-          :membership_is_active,
-          :is_picker,
-          :is_lead_picker,
-          :is_tree_owner
-        ]
+        select: ^@person_fields
       )
     )
   end
@@ -257,17 +179,7 @@ defmodule FruitPicker.Accounts do
         q in Person,
         where: q.is_lead_picker == true,
         order_by: [asc: q.last_name, asc: q.first_name],
-        select: [
-          :id,
-          :email,
-          :first_name,
-          :last_name,
-          :role,
-          :membership_is_active,
-          :is_picker,
-          :is_lead_picker,
-          :is_tree_owner
-        ]
+        select: ^@person_fields
       )
     )
   end
@@ -275,17 +187,7 @@ defmodule FruitPicker.Accounts do
   def list_lead_pickers(page, sort_by, desc \\ false) do
     Person
     |> where([lp], lp.is_lead_picker == true)
-    |> select([
-      :id,
-      :email,
-      :first_name,
-      :last_name,
-      :role,
-      :membership_is_active,
-      :is_picker,
-      :is_lead_picker,
-      :is_tree_owner
-    ])
+    |> select(^@person_fields)
     |> sort_people_query(sort_by, desc)
     |> Repo.paginate(page: page)
   end
@@ -295,17 +197,7 @@ defmodule FruitPicker.Accounts do
       from(
         q in Person,
         where: q.is_tree_owner == true,
-        select: [
-          :id,
-          :email,
-          :first_name,
-          :last_name,
-          :role,
-          :membership_is_active,
-          :is_picker,
-          :is_lead_picker,
-          :is_tree_owner
-        ]
+        select: ^@person_fields
       )
     )
   end

--- a/lib/fruit_picker/stats.ex
+++ b/lib/fruit_picker/stats.ex
@@ -36,6 +36,29 @@ defmodule FruitPicker.Stats do
     |> Repo.one()
   end
 
+  def tree_owner_season_stats(people) when is_list(people) do
+    today = Date.utc_today()
+    {:ok, season_start} = Date.new(today.year, 5, 1)
+
+    Pick
+    |> where([pick], pick.requester_id in ^Enum.map(people, & &1.id))
+    |> where(status: "completed")
+    |> where([pick], pick.scheduled_date > ^season_start)
+    |> join(:left, [pick], fruit in PickFruit, on: fruit.pick_id == pick.id)
+    |> group_by([pick], pick.requester_id)
+    |> select(
+      [pick, fruit],
+      {pick.requester_id,
+       %{
+         picks: count(pick.id),
+         pounds_picked: sum(fruit.total_pounds_picked),
+         pounds_donated: sum(fruit.total_pounds_donated)
+       }}
+    )
+    |> Repo.all()
+    |> Map.new()
+  end
+
   def tree_owner_total_stats(%Person{} = person) do
     Pick
     |> where(requester_id: ^person.id)
@@ -47,6 +70,25 @@ defmodule FruitPicker.Stats do
       "pounds_donated" => sum(fruit.total_pounds_donated)
     })
     |> Repo.one()
+  end
+
+  def tree_owner_total_stats(people) when is_list(people) do
+    Pick
+    |> where([pick], pick.requester_id in ^Enum.map(people, & &1.id))
+    |> where(status: "completed")
+    |> join(:left, [pick], fruit in PickFruit, on: fruit.pick_id == pick.id)
+    |> group_by([pick], pick.requester_id)
+    |> select(
+      [pick, fruit],
+      {pick.requester_id,
+       %{
+         picks: count(pick.id),
+         pounds_picked: sum(fruit.total_pounds_picked),
+         pounds_donated: sum(fruit.total_pounds_donated)
+       }}
+    )
+    |> Repo.all()
+    |> Map.new()
   end
 
   def lead_picker_season_stats(%Person{} = person) do
@@ -92,6 +134,56 @@ defmodule FruitPicker.Stats do
     }
   end
 
+  def lead_picker_season_stats(lead_pickers) when is_list(lead_pickers) do
+    lead_stats =
+      lead_pickers
+      |> Enum.map(& &1.id)
+      |> lead_query()
+      |> in_current_season()
+      |> Activities.exclude_busts()
+      |> get_lead_stats()
+      |> Repo.all()
+      |> Map.new(&{&1[:person_id], &1})
+
+    attended_stats =
+      lead_pickers
+      |> Enum.map(& &1.id)
+      |> attendance_query()
+      |> in_current_season()
+      |> Activities.exclude_busts()
+      |> get_attendance_stats()
+      |> Repo.all()
+      |> Map.new(&{&1[:person_id], &1})
+
+    for %{id: id} <- lead_pickers, into: %{} do
+      lead =
+        Map.get(lead_stats, id, %{
+          person_id: id,
+          picks: 0,
+          pounds_picked: 0,
+          pounds_donated: 0
+        })
+
+      attended =
+        Map.get(attended_stats, id, %{
+          person_id: id,
+          picks: 0,
+          pounds_picked: 0,
+          pounds_donated: 0
+        })
+
+      {id,
+       %{
+         person_id: id,
+         picks: lead.picks + attended.picks,
+         picks_lead: lead.picks,
+         picks_attended: attended.picks,
+         pounds_picked: lead.pounds_picked + attended.pounds_picked,
+         pounds_donated: lead.pounds_donated + attended.pounds_donated
+       }}
+    end
+  end
+
   def lead_picker_total_stats(%Person{} = person) do
     lead_stats =
       lead_query(person.id)
@@ -133,6 +225,54 @@ defmodule FruitPicker.Stats do
     }
   end
 
+  def lead_picker_total_stats(lead_pickers) when is_list(lead_pickers) do
+    lead_stats =
+      lead_pickers
+      |> Enum.map(& &1.id)
+      |> lead_query()
+      |> Activities.exclude_busts()
+      |> get_lead_stats()
+      |> Repo.all()
+      |> Map.new(&{&1[:person_id], &1})
+
+    attended_stats =
+      lead_pickers
+      |> Enum.map(& &1.id)
+      |> attendance_query()
+      |> Activities.exclude_busts()
+      |> get_attendance_stats()
+      |> Repo.all()
+      |> Map.new(&{&1[:person_id], &1})
+
+    for %{id: id} <- lead_pickers, into: %{} do
+      lead =
+        Map.get(lead_stats, id, %{
+          person_id: id,
+          picks: 0,
+          pounds_picked: 0,
+          pounds_donated: 0
+        })
+
+      attended =
+        Map.get(attended_stats, id, %{
+          person_id: id,
+          picks: 0,
+          pounds_picked: 0,
+          pounds_donated: 0
+        })
+
+      {id,
+       %{
+         person_id: id,
+         picks: lead[:picks] + attended[:picks],
+         picks_lead: lead.picks,
+         picks_attended: attended.picks,
+         pounds_picked: lead.pounds_picked + attended.pounds_picked,
+         pounds_donated: lead.pounds_donated + attended.pounds_donated
+       }}
+    end
+  end
+
   def picker_season_stats(%Person{} = person) do
     attended_stats =
       attendance_query(person.id)
@@ -157,6 +297,17 @@ defmodule FruitPicker.Stats do
       "pounds_picked" => attended_stats[:pounds_picked],
       "pounds_donated" => attended_stats[:pounds_donated]
     }
+  end
+
+  def picker_season_stats(pickers) when is_list(pickers) do
+    pickers
+    |> Enum.map(& &1.id)
+    |> attendance_query()
+    |> in_current_season()
+    |> Activities.exclude_busts()
+    |> get_attendance_stats()
+    |> Repo.all()
+    |> Map.new(&{&1[:person_id], &1})
   end
 
   def picker_total_stats(%Person{} = person) do
@@ -184,6 +335,16 @@ defmodule FruitPicker.Stats do
     }
   end
 
+  def picker_total_stats(pickers) when is_list(pickers) do
+    pickers
+    |> Enum.map(& &1.id)
+    |> attendance_query()
+    |> Activities.exclude_busts()
+    |> get_attendance_stats()
+    |> Repo.all()
+    |> Map.new(&{&1[:person_id], &1})
+  end
+
   def attendance_query() do
     from p in Pick,
       where: p.status == "completed",
@@ -194,20 +355,26 @@ defmodule FruitPicker.Stats do
       where: pa.did_attend == true
   end
 
-  def attendance_query(person_id) when is_number(person_id) do
+  defp attendance_query(person_id) when is_number(person_id) do
     from [pick_attendance: pa] in attendance_query(),
       where: pa.person_id == ^person_id
   end
 
-  def attendance_query(people_ids) when is_list(people_ids) do
+  defp attendance_query(people_ids) when is_list(people_ids) do
     from [pick_attendance: pa] in attendance_query(),
       where: pa.person_id in ^people_ids
   end
 
-  defp lead_query(person_id) do
+  defp lead_query(person_id) when is_number(person_id) do
     from p in Pick,
       where: p.status == "completed",
       where: p.lead_picker_id == ^person_id
+  end
+
+  defp lead_query(people_ids) when is_list(people_ids) do
+    from p in Pick,
+      where: p.status == "completed",
+      where: p.lead_picker_id in ^people_ids
   end
 
   defp in_current_season(query) do
@@ -256,6 +423,31 @@ defmodule FruitPicker.Stats do
     |> Repo.one()
   end
 
+  def agency_season_stats(people) when is_list(people) do
+    today = Date.utc_today()
+    {:ok, season_start} = Date.new(today.year, 5, 1)
+
+    Pick
+    |> join(:left, [pick], agency in Agency, on: agency.id == pick.agency_id)
+    |> where(
+      [pick, agency],
+      agency.partner_id in ^Enum.map(people, & &1.id) and pick.status == "completed"
+    )
+    |> where([pick, _], pick.scheduled_date > ^season_start)
+    |> join(:left, [pick, _], fruit in PickFruit, on: fruit.pick_id == pick.id)
+    |> group_by([_pick, agency], agency.partner_id)
+    |> select(
+      [pick, agency, fruit],
+      {agency.partner_id,
+       %{
+         picks: count(pick.id),
+         pounds_donated: sum(fruit.total_pounds_donated)
+       }}
+    )
+    |> Repo.all()
+    |> Map.new()
+  end
+
   def agency_total_stats(%Person{} = person) do
     Pick
     |> join(:left, [pick], agency in Agency, on: agency.id == pick.agency_id)
@@ -266,6 +458,27 @@ defmodule FruitPicker.Stats do
       "pounds_donated" => sum(fruit.total_pounds_donated)
     })
     |> Repo.one()
+  end
+
+  def agency_total_stats(people) when is_list(people) do
+    Pick
+    |> join(:left, [pick], agency in Agency, on: agency.id == pick.agency_id)
+    |> where(
+      [pick, agency],
+      agency.partner_id in ^Enum.map(people, & &1.id) and pick.status == "completed"
+    )
+    |> join(:left, [pick, _], fruit in PickFruit, on: fruit.pick_id == pick.id)
+    |> group_by([_pick, agency], agency.partner_id)
+    |> select(
+      [pick, agency, fruit],
+      {agency.partner_id,
+       %{
+         picks: count(pick.id),
+         pounds_donated: sum(fruit.total_pounds_donated)
+       }}
+    )
+    |> Repo.all()
+    |> Map.new()
   end
 
   def get_missed_picks_count(%Person{} = person) do

--- a/lib/fruit_picker/stats.ex
+++ b/lib/fruit_picker/stats.ex
@@ -126,14 +126,19 @@ defmodule FruitPicker.Stats do
     }
   end
 
-  defp attendance_query(person_id) do
+  def attendance_query() do
     from p in Pick,
       where: p.status == "completed",
       join: pr in assoc(p, :report),
       as: :pick_report,
       join: pa in assoc(pr, :attendees),
-      as: :pick_attendence,
-      where: pa.person_id == ^person_id and pa.did_attend == true
+      as: :pick_attendance,
+      where: pa.did_attend == true
+      end
+
+  def attendance_query(person_id) do
+    from [pick_attendance: pa] in attendance_query(),
+      where: pa.person_id == ^person_id
   end
 
   defp lead_query(person_id) do
@@ -150,7 +155,7 @@ defmodule FruitPicker.Stats do
       where: p.scheduled_date > ^season_start
   end
 
-  defp get_stats(query) do
+  def get_stats(query) do
     from [p, pick_fruits: pf] in Activities.with_pick_fruits(query),
       select: %{
         picks: count(p.id) |> coalesce(0),

--- a/lib/fruit_picker_web/controllers/admin/person_controller.ex
+++ b/lib/fruit_picker_web/controllers/admin/person_controller.ex
@@ -21,9 +21,13 @@ defmodule FruitPickerWeb.Admin.PersonController do
     sort_by = Map.get(params, "sort_by")
     desc = Map.get(params, "desc")
     page = Accounts.list_pickers(page_num, sort_by, desc)
+    total_stats = Stats.picker_total_stats(page.entries)
+    season_stats = Stats.picker_season_stats(page.entries)
 
     render(conn, "index.html",
       people: page.entries,
+      total_stats: total_stats,
+      season_stats: season_stats,
       page: page,
       people_count: page.total_entries,
       people_slug: "pickers",
@@ -39,8 +43,13 @@ defmodule FruitPickerWeb.Admin.PersonController do
     desc = Map.get(params, "desc")
     page = Accounts.list_lead_pickers(page_num, sort_by, desc)
 
+    total_stats = Stats.lead_picker_total_stats(page.entries)
+    season_stats = Stats.lead_picker_season_stats(page.entries)
+
     render(conn, "index.html",
       people: page.entries,
+      total_stats: total_stats,
+      season_stats: season_stats,
       page: page,
       people_count: page.total_entries,
       people_slug: "lead_pickers",
@@ -56,8 +65,13 @@ defmodule FruitPickerWeb.Admin.PersonController do
     desc = Map.get(params, "desc")
     page = Accounts.list_tree_owners(page_num, sort_by, desc)
 
+    total_stats = Stats.tree_owner_total_stats(page.entries)
+    season_stats = Stats.tree_owner_season_stats(page.entries)
+
     render(conn, "index.html",
       people: page.entries,
+      total_stats: total_stats,
+      season_stats: season_stats,
       page: page,
       people_count: page.total_entries,
       people_slug: "tree_owners",
@@ -73,8 +87,13 @@ defmodule FruitPickerWeb.Admin.PersonController do
     desc = Map.get(params, "desc")
     page = Accounts.list_agencies(page_num, sort_by, desc)
 
+    total_stats = Stats.agency_total_stats(page.entries)
+    season_stats = Stats.agency_season_stats(page.entries)
+
     render(conn, "index.html",
       people: page.entries,
+      total_stats: total_stats,
+      season_stats: season_stats,
       page: page,
       people_count: page.total_entries,
       people_slug: "agency_partners",
@@ -90,9 +109,14 @@ defmodule FruitPickerWeb.Admin.PersonController do
     desc = Map.get(params, "desc")
     page = Accounts.list_people(page_num, sort_by, desc)
 
+    total_stats = Stats.picker_total_stats(page.entries)
+    season_stats = Stats.picker_season_stats(page.entries)
+
     render(conn, "index.html",
       page: page,
       people: page.entries,
+      total_stats: total_stats,
+      season_stats: season_stats,
       people_count: page.total_entries,
       people_slug: "users",
       people_type: "users",
@@ -461,20 +485,22 @@ defmodule FruitPickerWeb.Admin.PersonController do
       end
 
     csv_data =
-      ([[
-         "id",
-         "first_name",
-         "last_name",
-         "role",
-         "picks attended this season",
-         "picks led this season",
-         "pounds picked this season",
-         "pounds donated this season",
-         "total picks attended",
-         "total picks led",
-         "total pounds picked",
-         "total pounds donated"
-       ]] ++ rows)
+      ([
+         [
+           "id",
+           "first_name",
+           "last_name",
+           "role",
+           "picks attended this season",
+           "picks led this season",
+           "pounds picked this season",
+           "pounds donated this season",
+           "total picks attended",
+           "total picks led",
+           "total pounds picked",
+           "total pounds donated"
+         ]
+       ] ++ rows)
       |> CSV.encode()
       |> Enum.to_list()
       |> to_string()

--- a/lib/fruit_picker_web/controllers/admin/person_controller.ex
+++ b/lib/fruit_picker_web/controllers/admin/person_controller.ex
@@ -462,25 +462,24 @@ defmodule FruitPickerWeb.Admin.PersonController do
 
   def export(conn, %{"type" => "lead_pickers"}) do
     lead_pickers = Accounts.list_lead_pickers()
+    total_stats = Stats.lead_picker_total_stats(lead_pickers)
+    season_stats = Stats.lead_picker_season_stats(lead_pickers)
 
     rows =
       for p <- lead_pickers do
-        season_stats = Stats.lead_picker_season_stats(p)
-        total_stats = Stats.lead_picker_total_stats(p)
-
         [
           p.id,
           p.first_name,
           p.last_name,
           FruitPickerWeb.Admin.PersonView.account_type(p),
-          season_stats["picks_attended"],
-          season_stats["picks_lead"],
-          season_stats["pounds_picked"],
-          season_stats["pounds_donated"],
-          total_stats["picks_attended"],
-          total_stats["picks_lead"],
-          total_stats["pounds_picked"],
-          total_stats["pounds_donated"]
+          get_in(season_stats, [p.id, :picks_attended]),
+          get_in(season_stats, [p.id, :picks_lead]),
+          get_in(season_stats, [p.id, :pounds_picked]),
+          get_in(season_stats, [p.id, :pounds_donated]),
+          get_in(total_stats, [p.id, :picks_attended]),
+          get_in(total_stats, [p.id, :picks_lead]),
+          get_in(total_stats, [p.id, :pounds_picked]),
+          get_in(total_stats, [p.id, :pounds_donated])
         ]
       end
 

--- a/lib/fruit_picker_web/templates/admin/person/index.html.slim
+++ b/lib/fruit_picker_web/templates/admin/person/index.html.slim
@@ -82,10 +82,10 @@ section.fl.w-100.pt4.pb5.bg-white
                     .pr1.truncate = Recase.to_title(account_type(person))
                 td.table-cell.mw4
                   a.flex.h-100.items-center.link.dark-gray.ttc href="#{Routes.admin_person_path(@conn, :show, person)}"
-                    .pr1.truncate = get_in(@total_stats, [person.id, :picks]) || "N/A"
+                    .pr1.truncate = get_in(@season_stats, [person.id, :picks]) || "N/A"
                 td.table-cell.mw4
                   a.flex.h-100.items-center.link.dark-gray.ttc href="#{Routes.admin_person_path(@conn, :show, person)}"
-                    .pr1.truncate = get_in(@season_stats, [person.id, :picks]) || "N/A"
+                    .pr1.truncate = get_in(@total_stats, [person.id, :picks]) || "N/A"
                 td.table-cell.mw4
                   a.flex.h-100.items-center.link.dark-gray.ttc href="#{Routes.admin_person_path(@conn, :show, person)}"
                     = if person.membership_is_active do

--- a/lib/fruit_picker_web/templates/admin/person/index.html.slim
+++ b/lib/fruit_picker_web/templates/admin/person/index.html.slim
@@ -82,10 +82,10 @@ section.fl.w-100.pt4.pb5.bg-white
                     .pr1.truncate = Recase.to_title(account_type(person))
                 td.table-cell.mw4
                   a.flex.h-100.items-center.link.dark-gray.ttc href="#{Routes.admin_person_path(@conn, :show, person)}"
-                    .pr1.truncate N/A
+                    .pr1.truncate = get_in(@total_stats, [person.id, :picks]) || "N/A"
                 td.table-cell.mw4
                   a.flex.h-100.items-center.link.dark-gray.ttc href="#{Routes.admin_person_path(@conn, :show, person)}"
-                    .pr1.truncate N/A
+                    .pr1.truncate = get_in(@season_stats, [person.id, :picks]) || "N/A"
                 td.table-cell.mw4
                   a.flex.h-100.items-center.link.dark-gray.ttc href="#{Routes.admin_person_path(@conn, :show, person)}"
                     = if person.membership_is_active do

--- a/lib/fruit_picker_web/templates/admin/person/index.html.slim
+++ b/lib/fruit_picker_web/templates/admin/person/index.html.slim
@@ -17,10 +17,8 @@ header.fl.w-100.bg-dark-gray
 section.fl.w-100.pt4.pb5.bg-white
   .mw-container.center.ph2.ph4-l
     section.flex.justify-end
-      = if @people_slug == "lead_pickers" do
+      = if @people_slug in ["pickers", "lead_pickers", "tree_owners", "agency_partners"] do
         a.self-end.input-reset.link.br2.h50px.ph4.bg-green.hover-bg-dark-green.white.tc.bn.flex.justify-center.items-center.pointer href="#{Routes.admin_person_path(@conn, :export, %{"type" => @people_slug})}" Export CSV
-      - else
-        div.self-end.pt1.i Export only available for lead pickers
     section.flex.pv1.justify-between.items-center
       h5.normal.dark-gray.f5
         | Total Number of&nbsp;


### PR DESCRIPTION
Previously the number of picks for users was always just "N/A"

Now we show how many picks and picks this season each type of user has:

![CleanShot 2024-05-16 at 17 20 16](https://github.com/nfftt/portal/assets/34720/36715b1e-8d41-450f-8c56-8536ee1e9f2d)

We also add an export for pickers, tree owners, lead pickers, and agencies.

![CleanShot 2024-05-17 at 13 10 15@2x](https://github.com/nfftt/portal/assets/34720/e80be7fa-5d1c-4f11-b903-f567041459ea)


This is needed for #51 