### PR TITLE
Fix issue with empty agency

### DIFF
--- a/lib/fruit_picker_web/templates/email/home_owner_pick_scheduled.html.slim
+++ b/lib/fruit_picker_web/templates/email/home_owner_pick_scheduled.html.slim
@@ -5,7 +5,7 @@ tr
 
     p Good news – we’ve scheduled your #{PickView.tree_type(@pick)} pick for #{SharedView.friendly_date(@pick.scheduled_date)} from #{SharedView.twelve_hour_time(@pick.scheduled_start_time)} to #{SharedView.twelve_hour_time(@pick.scheduled_end_time)}!
 
-    p #{@pick.lead_picker.first_name} and their team of Fruit Pickers will arrive on site and pick as much as they can for 2 hours. After the pick, #{@pick.lead_picker.first_name} will be delivering ⅓ of the fruit by cargo bike to #{@pick.agency.name}. No need to be home, unless there’s something that needs to be unlocked for the team to access your tree.
+    p #{@pick.lead_picker.first_name} and their team of Fruit Pickers will arrive on site and pick as much as they can for 2 hours. After the pick, #{@pick.lead_picker.first_name} will be delivering ⅓ of the fruit by cargo bike to #{PickView.agency_name(@pick)}. No need to be home, unless there’s something that needs to be unlocked for the team to access your tree.
 
     p Please leave out:
 

--- a/lib/fruit_picker_web/templates/email/home_owner_pick_scheduled.text.eex
+++ b/lib/fruit_picker_web/templates/email/home_owner_pick_scheduled.text.eex
@@ -2,7 +2,8 @@ Hi <%= @pick.requester.first_name %>,
 
 Good news – we’ve scheduled your <%= PickView.tree_type(@pick) %> pick for <%= SharedView.friendly_date(@pick.scheduled_date) %> from <%= SharedView.twelve_hour_time(@pick.scheduled_start_time) %> to <%= SharedView.twelve_hour_time(@pick.scheduled_end_time) %>!
 
-<%= @pick.lead_picker.first_name %> and their team of Fruit Pickers will arrive on site and pick as much as they can for 2 hours. After the pick, <%= @pick.lead_picker.first_name %> will be delivering ⅓ of the fruit by cargo bike to <%= @pick.agency.name %>. No need to be home, unless there’s something that needs to be unlocked for the team to access your tree.
+alias FruitPickerWeb.Admin.PickView
+<%= @pick.lead_picker.first_name %> and their team of Fruit Pickers will arrive on site and pick as much as they can for 2 hours. After the pick, <%= @pick.lead_picker.first_name %> will be delivering ⅓ of the fruit by cargo bike to <%= PickView.agency_name(@pick) %>. No need to be home, unless there’s something that needs to be unlocked for the team to access your tree.
 
 Please leave out:
 

--- a/lib/fruit_picker_web/templates/email/pick_completion_tree_owner.html.slim
+++ b/lib/fruit_picker_web/templates/email/pick_completion_tree_owner.html.slim
@@ -3,7 +3,7 @@ tr
 
     p Hello #{@pick.requester.first_name},
 
-    p Your #{PickView.tree_type(@pick)} tree(s) provided #{FruitPicker.Activities.get_total_pick_fruit_weight(@pick)}lb(s) of fresh #{PickView.tree_type(@pick)} that were donated to the #{@pick.agency.name} and diverted from the landfill!
+    p Your #{PickView.tree_type(@pick)} tree(s) provided #{FruitPicker.Activities.get_total_pick_fruit_weight(@pick)}lb(s) of fresh #{PickView.tree_type(@pick)} that were donated to the #{PickView.agency_name(@pick)} and diverted from the landfill!
 
     p By sharing your fruit tree with NFFTTT, your yard becomes a hub for community connection and knowledge sharing for diverse fruit pickers traveling from across the GTA with diverse backgrounds and life experiences to enjoy the outdoors! Picking fresh fruit is a cheerful experience and collaborative event when our fruit picking team, including service agency partners bring their clients together to experience the joy of dynamic urban outdoor spaces while learning about and stewarding the urban canopy!
 

--- a/lib/fruit_picker_web/templates/email/pick_completion_tree_owner.text.eex
+++ b/lib/fruit_picker_web/templates/email/pick_completion_tree_owner.text.eex
@@ -1,6 +1,6 @@
 Hello <%= @pick.requester.first_name %>,
 
-Your <%= PickView.tree_type(@pick) %> tree(s) provided <%= FruitPicker.Activities.get_total_pick_fruit_weight(@pick) %>lb(s) of fresh <%= PickView.tree_type(@pick) %> that were donated to the <%= @pick.agency.name %> and diverted from the landfill!
+Your <%= PickView.tree_type(@pick) %> tree(s) provided <%= FruitPicker.Activities.get_total_pick_fruit_weight(@pick) %>lb(s) of fresh <%= PickView.tree_type(@pick) %> that were donated to the <%= PickView.agency_name(@pick) %> and diverted from the landfill!
 
 By sharing your fruit tree with NFFTTT, your yard becomes a hub for community connection and knowledge sharing for diverse fruit pickers traveling from across the GTA with diverse backgrounds and life experiences to enjoy the outdoors! Picking fresh fruit is a cheerful experience and collaborative event when our fruit picking team, including service agency partners bring their clients together to experience the joy of dynamic urban outdoor spaces while learning about and stewarding the urban canopy!
 

--- a/lib/fruit_picker_web/templates/pick/show.html.slim
+++ b/lib/fruit_picker_web/templates/pick/show.html.slim
@@ -90,9 +90,9 @@ section.fl.w-100.pt4.mb4.mb0-l.relative.bg-white class=show_team_class(@pick, @c
           .flex.flex-column.mb4.w-100
             span.dark-gray.mb2 Property Owner
             p.light-gray.mv0.lh-copy = SharedView.full_name(@pick.requester)
-          
+
           .flex.flex-wrap.flex-nowrap-l.mw-40
-        
+
             .flex.flex-column.mb4.w-100.w-50-l.mr2-l
               span.dark-gray.mb2 Email
               p.light-gray.mv0.lh-copy = @pick.requester.email
@@ -400,7 +400,7 @@ section.fl.w-100.pt4.mb4.mb0-l.relative.bg-white class=show_team_class(@pick, @c
           = if @pick.report.other_details do
             h5.f5.normal.dark-gray.lh-copy.mv0 Yes
             p.dark-gray.mv0.lh-copy = @pick.report.other_details
-          - else 
+          - else
             h5.f5.normal.dark-gray.lh-copy.mv0 No
 
       hr.h1px.bn.bg-moon-gray

--- a/lib/fruit_picker_web/views/pick_view.ex
+++ b/lib/fruit_picker_web/views/pick_view.ex
@@ -409,4 +409,14 @@ defmodule FruitPickerWeb.PickView do
       pick.lead_picker.id == pick.report.submitter.id and
       pick.report.is_complete
   end
+
+
+  def agency_name(%Pick{} = pick) do
+    if pick.agency do
+      pick.agency.name
+    else
+      "a partner agency"
+    end
+  end
+
 end


### PR DESCRIPTION
See: https://nfftt.sentry.io/issues/5565526424/?project=1409762&query=is%3Aunresolved+issue.priority%3A%5Bhigh%2C+medium%5D&referrer=issue-stream&stream_index=3

When a pick doesn't have an associated agency with it our emails will error out. This issue was also spotted by @RachelNFFTT 