### PR TITLE
Don't send emails to users who opt-out or are inactive

### DIFF
--- a/lib/fruit_picker/accounts/person.ex
+++ b/lib/fruit_picker/accounts/person.ex
@@ -37,7 +37,8 @@ defmodule FruitPicker.Accounts.Person do
     field(:accepts_consent_picker, :boolean, default: false)
     field(:accepts_consent_tree_owner, :boolean, default: false)
     field(:membership_is_active, :boolean, default: false)
-    field(:number_picks_trigger_waitlist, :integer) #the default is 5
+    # the default is 5
+    field(:number_picks_trigger_waitlist, :integer)
 
     has_one(:profile, Profile, on_delete: :delete_all)
     has_one(:property, Property)
@@ -215,14 +216,11 @@ defmodule FruitPicker.Accounts.Person do
   def preload_property(%Ecto.Query{} = query), do: Ecto.Query.preload(query, :property)
   def preload_property(person), do: Repo.preload(person, :property)
 
-  def admins, do: from(p in Person, where: p.role == ^:admin)
   def admins(query \\ __MODULE__), do: from(q in query, where: q.role == ^:admin)
 
-  def lead_pickers, do: from(p in Person, where: p.is_lead_picker == true)
   def lead_pickers(query \\ __MODULE__), do: from(q in query, where: q.is_lead_picker == true)
 
-  def active, do: from(p in Person, where: p.is_active == true)
-  def active(query \\ __MODULE__), do: from(q in query, where: q.is_active == true)
+  def active(query \\ __MODULE__), do: from(q in query, where: q.membership_is_active == true)
 
   defp validate_consent(changeset, account_type) do
     cond do

--- a/lib/fruit_picker_web/controllers/admin/pick_controller.ex
+++ b/lib/fruit_picker_web/controllers/admin/pick_controller.ex
@@ -613,7 +613,10 @@ defmodule FruitPickerWeb.Admin.PickController do
   end
 
   defp email_lead_pickers_new_pick(%Pick{} = pick) do
-    lead_pickers = Repo.all(Person.lead_pickers())
+    lead_pickers =
+      Person.lead_pickers()
+      |> Person.active()
+      |> Repo.all()
 
     Enum.each(lead_pickers, fn lp ->
       lp
@@ -635,7 +638,10 @@ defmodule FruitPickerWeb.Admin.PickController do
   end
 
   defp email_admins_pick_cancelation(%Pick{} = pick, canceler, reason) do
-    admins = Repo.all(Person.admins())
+    admins =
+      Person.admins()
+      |> Person.active()
+      |> Repo.all()
 
     Enum.each(admins, fn a ->
       a

--- a/lib/fruit_picker_web/controllers/pick_report_controller.ex
+++ b/lib/fruit_picker_web/controllers/pick_report_controller.ex
@@ -54,7 +54,7 @@ defmodule FruitPickerWeb.PickReportController do
         |> put_flash(:error, "You don't have permission to create this report")
         |> redirect(to: pick_path(conn, me, pick))
 
-     can_edit?(pick, me) ->
+      can_edit?(pick, me) ->
         render(conn, "new.html",
           pick: pick,
           changeset: changeset
@@ -260,7 +260,10 @@ defmodule FruitPickerWeb.PickReportController do
   end
 
   defp email_admin_report_issue(%Pick{} = pick) do
-    admins = Repo.all(Person.admins())
+    admins =
+      Person.admins()
+      |> Person.active()
+      |> Repo.all()
 
     Enum.each(admins, fn a ->
       a

--- a/lib/fruit_picker_web/controllers/register_controller.ex
+++ b/lib/fruit_picker_web/controllers/register_controller.ex
@@ -13,11 +13,12 @@ defmodule FruitPickerWeb.RegisterController do
     if account_type in ["fruit_picker", "tree_owner"] do
       profile_changeset = Accounts.change_profile(%Profile{})
       person_changeset = Accounts.change_person(%Person{profile: profile_changeset})
+
       render(
         conn,
         "form.html",
         changeset: person_changeset,
-        account_type: account_type,
+        account_type: account_type
       )
     else
       conn
@@ -47,7 +48,7 @@ defmodule FruitPickerWeb.RegisterController do
         |> render(
           "form.html",
           changeset: changeset,
-          account_type: account_type,
+          account_type: account_type
         )
     end
   end
@@ -56,12 +57,20 @@ defmodule FruitPickerWeb.RegisterController do
     cond do
       person.is_picker ->
         conn
-        |> put_flash(:info, "Thanks for registering with NFFTT! Please complete your season membership payment to continue.")
+        |> put_flash(
+          :info,
+          "Thanks for registering with NFFTT! Please complete your season membership payment to continue."
+        )
         |> redirect(to: Routes.profile_path(conn, :show, payment: true))
+
       person.is_tree_owner ->
         conn
-        |> put_flash(:info, "Thanks for registering with NFFTT! Please setup your property and trees next.")
+        |> put_flash(
+          :info,
+          "Thanks for registering with NFFTT! Please setup your property and trees next."
+        )
         |> redirect(to: Routes.property_path(conn, :new))
+
       true ->
         conn
         |> redirect(to: Routes.profile_path(conn, :show))
@@ -69,7 +78,11 @@ defmodule FruitPickerWeb.RegisterController do
   end
 
   defp email_admins_new_registration(%Person{} = person, role) do
-    admins = Repo.all(Person.admins())
+    admins =
+      Person.admins()
+      |> Person.active()
+      |> Repo.all()
+
     role = Recase.to_title(role)
 
     Enum.each(admins, fn a ->

--- a/lib/fruit_picker_web/email.ex
+++ b/lib/fruit_picker_web/email.ex
@@ -10,10 +10,11 @@ defmodule FruitPickerWeb.Email do
 
   def password_reset(token_value, person) do
     Logger.info(
-      "Sending password reset token email to #{person.first_name} #{person.last_name} (#{
-        person.id
-      })."
+      "Sending password reset token email to #{person.first_name} #{person.last_name} (#{person.id})."
     )
+
+    # we want to send the password reset emails even if they declined portal communications
+    person = %{person | accepts_portal_communications: true}
 
     bot_email()
     |> to(person)
@@ -25,9 +26,7 @@ defmodule FruitPickerWeb.Email do
 
   def new_registration(admin, person, role) do
     Logger.info(
-      "Sending new registration email to #{admin.first_name} #{admin.last_name} (#{admin.id}) for person #{
-        person.id
-      }."
+      "Sending new registration email to #{admin.first_name} #{admin.last_name} (#{admin.id}) for person #{person.id}."
     )
 
     bot_email()
@@ -41,9 +40,7 @@ defmodule FruitPickerWeb.Email do
 
   def new_public_pick(person, pick) do
     Logger.info(
-      "Sending new public pick email to #{person.first_name} #{person.last_name} (#{person.id}) for pick #{
-        pick.id
-      }."
+      "Sending new public pick email to #{person.first_name} #{person.last_name} (#{person.id}) for pick #{pick.id}."
     )
 
     bot_email()
@@ -56,16 +53,12 @@ defmodule FruitPickerWeb.Email do
 
   def home_owner_pick_is_scheduled(pick) do
     subject =
-      "#{pick.id}: Your Pick has been scheduled for #{SharedView.short_date(pick.scheduled_date)} from #{
-        SharedView.twelve_hour_time(pick.scheduled_start_time)
-      } to #{SharedView.twelve_hour_time(pick.scheduled_end_time)}"
+      "#{pick.id}: Your Pick has been scheduled for #{SharedView.short_date(pick.scheduled_date)} from #{SharedView.twelve_hour_time(pick.scheduled_start_time)} to #{SharedView.twelve_hour_time(pick.scheduled_end_time)}"
 
     person = pick.requester
 
     Logger.info(
-      "Sending tree owner pick is scheduled email to #{person.first_name} #{person.last_name} (#{
-        person.id
-      }) for pick #{pick.id}."
+      "Sending tree owner pick is scheduled email to #{person.first_name} #{person.last_name} (#{person.id}) for pick #{pick.id}."
     )
 
     bot_email()
@@ -77,9 +70,7 @@ defmodule FruitPickerWeb.Email do
 
   def agency_pick_is_scheduled(pick, agency) do
     subject =
-      "#{pick.id}: #{PickView.tree_type(pick)} Delivery – #{
-        SharedView.short_date(pick.scheduled_date)
-      } shortly after #{SharedView.twelve_hour_time(pick.scheduled_end_time)}"
+      "#{pick.id}: #{PickView.tree_type(pick)} Delivery – #{SharedView.short_date(pick.scheduled_date)} shortly after #{SharedView.twelve_hour_time(pick.scheduled_end_time)}"
 
     if agency.contact_email do
       bot_email()
@@ -97,9 +88,7 @@ defmodule FruitPickerWeb.Email do
 
   def pick_request_confirmation(person, pick) do
     Logger.info(
-      "Sending pick request confirmation email to #{person.first_name} #{person.last_name} (#{
-        person.id
-      }) for pick #{pick.id}."
+      "Sending pick request confirmation email to #{person.first_name} #{person.last_name} (#{person.id}) for pick #{pick.id}."
     )
 
     bot_email()
@@ -112,9 +101,7 @@ defmodule FruitPickerWeb.Email do
 
   def fruit_picker_payment_email(person) do
     Logger.info(
-      "Sending fruit picker payment email to #{person.first_name} #{person.last_name} (#{
-        person.id
-      })."
+      "Sending fruit picker payment email to #{person.first_name} #{person.last_name} (#{person.id})."
     )
 
     bot_email()
@@ -138,9 +125,7 @@ defmodule FruitPickerWeb.Email do
 
   def daily_picks_available_email(person, picks) do
     Logger.info(
-      "Sending daily picks available email to #{person.first_name} #{person.last_name} (#{
-        person.id
-      })."
+      "Sending daily picks available email to #{person.first_name} #{person.last_name} (#{person.id})."
     )
 
     bot_email()
@@ -179,9 +164,7 @@ defmodule FruitPickerWeb.Email do
 
   def admin_report_issue(admin, pick) do
     Logger.info(
-      "Sending pick report issue email to #{admin.first_name} #{admin.last_name} (#{admin.id}) for pick #{
-        pick.id
-      }."
+      "Sending pick report issue email to #{admin.first_name} #{admin.last_name} (#{admin.id}) for pick #{pick.id}."
     )
 
     bot_email()
@@ -277,9 +260,7 @@ defmodule FruitPickerWeb.Email do
 
   def outstanding_report_reminder_email(pick, lead_picker) do
     Logger.info(
-      "Sending oustanding pick report (pick ##{pick.id}) to lead picker #{lead_picker.first_name} #{
-        lead_picker.last_name
-      }"
+      "Sending oustanding pick report (pick ##{pick.id}) to lead picker #{lead_picker.first_name} #{lead_picker.last_name}"
     )
 
     bot_email()
@@ -307,9 +288,7 @@ defmodule FruitPickerWeb.Email do
     bot_email()
     |> to(person)
     |> subject(
-      "#{pick.id}: You are attending a #{PickView.tree_type(pick)} Pick tomorrow from #{
-        SharedView.twelve_hour_time(pick.scheduled_start_time)
-      } to #{SharedView.twelve_hour_time(pick.scheduled_end_time)}"
+      "#{pick.id}: You are attending a #{PickView.tree_type(pick)} Pick tomorrow from #{SharedView.twelve_hour_time(pick.scheduled_start_time)} to #{SharedView.twelve_hour_time(pick.scheduled_end_time)}"
     )
     |> assign(:person, person)
     |> assign(:pick, pick)
@@ -322,9 +301,7 @@ defmodule FruitPickerWeb.Email do
     bot_email()
     |> to({agency.contact_name, agency.contact_email})
     |> subject(
-      "#{pick.id}: Reminder - #{PickView.tree_type(pick)} Delivery - #{
-        SharedView.short_date(pick.scheduled_date)
-      } shortly after #{SharedView.twelve_hour_time(pick.scheduled_end_time)}"
+      "#{pick.id}: Reminder - #{PickView.tree_type(pick)} Delivery - #{SharedView.short_date(pick.scheduled_date)} shortly after #{SharedView.twelve_hour_time(pick.scheduled_end_time)}"
     )
     |> assign(:agency, agency)
     |> assign(:pick, pick)
@@ -357,7 +334,10 @@ defmodule FruitPickerWeb.Email do
 
   defimpl Bamboo.Formatter, for: FruitPicker.Accounts.Person do
     def format_email_address(person, _opts) do
-      {person.first_name <> person.last_name, person.email}
+      # Only send emails to people who accept portal communications
+      if person.accepts_portal_communications do
+        {person.first_name <> person.last_name, person.email}
+      end
     end
   end
 end


### PR DESCRIPTION
1) If a user is opted out of portal communications we don't send emails to them (except password reset emails under the assumption that they may want that in order to un-reset their password).
2) When a pick is created/cancelled/etc we only send emails to active admins / pick leaders about it.

Closes #https://github.com/nfftt/portal/issues/98