### PR TITLE
Soft delete users

### DIFF
--- a/lib/fruit_picker/accounts.ex
+++ b/lib/fruit_picker/accounts.ex
@@ -558,6 +558,10 @@ defmodule FruitPicker.Accounts do
     person.profile
     |> Repo.delete()
 
+    person.property
+    |> Property.soft_delete_changeset()
+    |> Repo.update()
+
     # Properties are not deleted for reporting purposes
     person
     |> Person.soft_delete_changeset()

--- a/lib/fruit_picker/accounts.ex
+++ b/lib/fruit_picker/accounts.ex
@@ -551,8 +551,13 @@ defmodule FruitPicker.Accounts do
 
   """
   def soft_delete_person(%Person{} = person) do
+    # Delete the associated profile
+    person.profile
+    |> Repo.delete()
+
+    # Properties are not deleted for reporting purposes
     person
-    |> Ecto.Changeset.change(deleted: true)
+    |> Person.soft_delete_changeset()
     |> Repo.update()
   end
 

--- a/lib/fruit_picker/accounts.ex
+++ b/lib/fruit_picker/accounts.ex
@@ -474,6 +474,9 @@ defmodule FruitPicker.Accounts do
   """
   def get_person!(id), do: Person |> Repo.get!(id) |> Person.preload_all()
 
+  def get_not_deleted_person!(id),
+    do: Person |> not_deleted() |> Repo.get!(id) |> Person.preload_all()
+
   def get_activ_tree_owner(id) do
     Person
     |> where([p], p.id == ^id)

--- a/lib/fruit_picker/accounts/person.ex
+++ b/lib/fruit_picker/accounts/person.ex
@@ -40,6 +40,8 @@ defmodule FruitPicker.Accounts.Person do
     # the default is 5
     field(:number_picks_trigger_waitlist, :integer)
 
+    field(:deleted, :boolean, default: false)
+
     has_one(:profile, Profile, on_delete: :delete_all)
     has_one(:property, Property)
     has_one(:agency, Agency)

--- a/lib/fruit_picker/accounts/person.ex
+++ b/lib/fruit_picker/accounts/person.ex
@@ -199,6 +199,21 @@ defmodule FruitPicker.Accounts.Person do
   end
 
   @doc false
+  def soft_delete_changeset(%Person{} = person) do
+    change(person, %{
+      email: nil,
+      first_name: nil,
+      last_name: nil,
+      password_hash: nil,
+      avatar: nil,
+      # stripe_customer_id: nil, # keeping this for now for reporting
+      deleted: true,
+      membership_is_active: false,
+      accepts_portal_communications: false
+    })
+  end
+
+  @doc false
   defp put_pass_hash(%Ecto.Changeset{valid?: true, changes: %{password: pass}} = changeset) do
     change(changeset, add_hash(pass))
   end

--- a/lib/fruit_picker/accounts/property.ex
+++ b/lib/fruit_picker/accounts/property.ex
@@ -23,6 +23,7 @@ defmodule FruitPicker.Accounts.Property do
     field(:ladder_provided, :string)
     field(:tree_owner_takes, :string)
     field(:notes, :string)
+    field(:deleted, :boolean, default: false)
 
     field(:is_in_operating_area, :boolean)
     field(:coordinates_updated_at, :naive_datetime_usec)
@@ -51,7 +52,7 @@ defmodule FruitPicker.Accounts.Property do
       :address_street,
       :address_closest_intersection,
       :address_city,
-      :address_postal_code,
+      :address_postal_code
     ])
     |> assoc_constraint(:person)
   end
@@ -75,7 +76,7 @@ defmodule FruitPicker.Accounts.Property do
       :address_street,
       :address_closest_intersection,
       :address_city,
-      :address_postal_code,
+      :address_postal_code
     ])
     |> assoc_constraint(:person)
   end
@@ -95,5 +96,17 @@ defmodule FruitPicker.Accounts.Property do
       :coordinates_updated_at,
       NaiveDateTime.utc_now()
     )
+  end
+
+  @doc false
+  def soft_delete_changeset(property) do
+    change(property, %{
+      address_street: nil,
+      latitude: nil,
+      longitude: nil,
+      coordinates_updated_at: NaiveDateTime.utc_now(),
+      notes: nil,
+      deleted: true
+    })
   end
 end

--- a/lib/fruit_picker_web/controllers/admin/person_controller.ex
+++ b/lib/fruit_picker_web/controllers/admin/person_controller.ex
@@ -445,7 +445,7 @@ defmodule FruitPickerWeb.Admin.PersonController do
 
   def delete(conn, %{"id" => id}) do
     person = Accounts.get_person!(id)
-    {:ok, _person} = Accounts.delete_person(person)
+    {:ok, _person} = Accounts.soft_delete_person(person)
 
     conn
     |> put_flash(:info, "Person deleted successfully.")

--- a/lib/fruit_picker_web/plugs/auth_plug.ex
+++ b/lib/fruit_picker_web/plugs/auth_plug.ex
@@ -17,7 +17,8 @@ defmodule FruitPickerWeb.Plugs.Auth do
     person_id = get_session(conn, :person_id)
 
     try do
-      person = person_id && Accounts.get_person!(person_id)
+      person = person_id && Accounts.get_not_deleted_person!(person_id)
+
       setup_sentry_context(person)
       assign(conn, :current_person, person)
     rescue

--- a/lib/fruit_picker_web/templates/admin/person/show.html.slim
+++ b/lib/fruit_picker_web/templates/admin/person/show.html.slim
@@ -43,51 +43,52 @@ section.fl.w-100.pt4.pb5.bg-white
 
     hr.h1px.bn.bg-moon-gray
 
-    section.w-100.pv4
-      .flex.items-center.mw-40.mb4
-        h6.w-100.f3.fw5.dark-gray.mv0.lh-title Personal Information
-        = link "Edit", to: Routes.admin_person_path(@conn, :edit, @person), class: "link green hover-dark-green"
+    = if @person.profile do
+      section.w-100.pv4
+        .flex.items-center.mw-40.mb4
+          h6.w-100.f3.fw5.dark-gray.mv0.lh-title Personal Information
+          = link "Edit", to: Routes.admin_person_path(@conn, :edit, @person), class: "link green hover-dark-green"
 
-      .flex.flex-wrap.flex-nowrap-l.mw-40
+        .flex.flex-wrap.flex-nowrap-l.mw-40
 
-        .flex.flex-column.mb4.w-100.w-50-l.mr2-l
-          span.dark-gray.mb2 First Name
-          p.light-gray.mv0.lh-copy = @person.first_name
+          .flex.flex-column.mb4.w-100.w-50-l.mr2-l
+            span.dark-gray.mb2 First Name
+            p.light-gray.mv0.lh-copy = @person.first_name
 
-        .flex.flex-column.mb4.w-100.w-50-l.ml2-l
-          span.dark-gray.mb2 Last Name
-          p.light-gray.mv0.lh-copy = @person.last_name
+          .flex.flex-column.mb4.w-100.w-50-l.ml2-l
+            span.dark-gray.mb2 Last Name
+            p.light-gray.mv0.lh-copy = @person.last_name
 
-      .flex.flex-wrap.flex-nowrap-l.mw-40
+        .flex.flex-wrap.flex-nowrap-l.mw-40
 
-        .flex.flex-column.mb4.w-100.w-50-l.mr2-l
-          span.dark-gray.mb2 Phone Number
-          p.light-gray.mv0.lh-copy = @person.profile.phone_number
+          .flex.flex-column.mb4.w-100.w-50-l.mr2-l
+            span.dark-gray.mb2 Phone Number
+            p.light-gray.mv0.lh-copy = @person.profile.phone_number
 
-        .flex.flex-column.mb4.w-100.w-50-l.ml2-l
-          span.dark-gray.mb2
-            | Secondary Number
-            i.i.light-gray
-              | &nbsp;(Optional)
-          p.light-gray.mv0.lh-copy = @person.profile.secondary_phone_number
+          .flex.flex-column.mb4.w-100.w-50-l.ml2-l
+            span.dark-gray.mb2
+              | Secondary Number
+              i.i.light-gray
+                | &nbsp;(Optional)
+            p.light-gray.mv0.lh-copy = @person.profile.secondary_phone_number
 
-      .flex.flex-column.mb4.w-100.mw-40
-        span.dark-gray.mb2 Home Address
-        p.light-gray.mv0.lh-copy = @person.profile.address_street
+        .flex.flex-column.mb4.w-100.mw-40
+          span.dark-gray.mb2 Home Address
+          p.light-gray.mv0.lh-copy = @person.profile.address_street
 
-      .flex.flex-wrap.flex-nowrap-l.mw-40
+        .flex.flex-wrap.flex-nowrap-l.mw-40
 
-        .flex.flex-column.mb4.w-100.w-50-l.mr2-l
-          span.dark-gray.mb2 City
-          p.light-gray.mv0.lh-copy = @person.profile.address_city
+          .flex.flex-column.mb4.w-100.w-50-l.mr2-l
+            span.dark-gray.mb2 City
+            p.light-gray.mv0.lh-copy = @person.profile.address_city
 
-        .flex.flex-column.mb4.w-100.w-50-l.ml2-l
-          span.dark-gray.mb2 Province
-          p.light-gray.mv0.lh-copy = @person.profile.address_province
+          .flex.flex-column.mb4.w-100.w-50-l.ml2-l
+            span.dark-gray.mb2 Province
+            p.light-gray.mv0.lh-copy = @person.profile.address_province
 
-      .flex.flex-column.mb4.w-100.mw-40
-        span.dark-gray.mb2 Postal Code
-        p.light-gray.mv0.lh-copy = @person.profile.address_postal_code
+        .flex.flex-column.mb4.w-100.mw-40
+          span.dark-gray.mb2 Postal Code
+          p.light-gray.mv0.lh-copy = @person.profile.address_postal_code
 
 
     hr.h1px.bn.bg-moon-gray
@@ -96,6 +97,10 @@ section.fl.w-100.pt4.pb5.bg-white
       .flex.items-center.mw-40.mb4
         h6.w-100.f3.fw5.dark-gray.mv0.lh-title Account Details
         = link "Edit", to: Routes.admin_person_path(@conn, :edit, @person), class: "link green hover-dark-green"
+
+      = if @person.deleted do
+        .flex.flex-column.mb3.w-100.mw-40
+          span.dark-gray.mb2.fw5 Account is deleted
 
       .flex.flex-column.mb3.w-100.mw-40
         span.dark-gray.mb2 Email Address

--- a/lib/fruit_picker_web/templates/admin/property/show.html.slim
+++ b/lib/fruit_picker_web/templates/admin/property/show.html.slim
@@ -81,6 +81,10 @@ section.fl.w-100.pb5.bg-white
         h6.w-100.f3.fw5.dark-gray.mv0.lh-title Property Details
         = link "Edit", to: Routes.admin_property_path(@conn, :edit, @person), class: "link green hover-dark-green"
 
+      = if @person.deleted do
+      .flex.flex-column.mb3.w-100.mw-40
+        span.dark-gray.mb2.fw5 Property is deleted
+
       .flex.flex-wrap.flex-nowrap-l.mw-40
 
         .flex.flex-column.mb4.w-100.w-50-l.mr2-l

--- a/lib/fruit_picker_web/views/admin/person_view.ex
+++ b/lib/fruit_picker_web/views/admin/person_view.ex
@@ -104,6 +104,7 @@ defmodule FruitPickerWeb.Admin.PersonView do
     end
   end
 
+  defp gravatar_url(nil, _version), do: "https://www.gravatar.com/avatar"
   defp gravatar_url(email, version) do
     size = case version do
              :small  -> 100

--- a/lib/fruit_picker_web/views/admin/person_view.ex
+++ b/lib/fruit_picker_web/views/admin/person_view.ex
@@ -83,41 +83,6 @@ defmodule FruitPickerWeb.Admin.PersonView do
     ]
   end
 
-  def avatar_path(person, version) do
-    {person.avatar, person}
-    |> Avatar.url(version, signed: true)
-    |> String.replace_leading("/priv", "")
-  end
-
-  def avatar_url(person), do: avatar_url(person, :small)
-  def avatar_url(person, version) do
-    if person.avatar do
-      url = avatar_path(person, version)
-
-      if String.starts_with?(url, "/") do
-        Routes.static_url(Endpoint, avatar_path(person, version))
-      else
-        url
-      end
-    else
-      gravatar_url(person.email, version)
-    end
-  end
-
-  defp gravatar_url(nil, _version), do: "https://www.gravatar.com/avatar"
-  defp gravatar_url(email, version) do
-    size = case version do
-             :small  -> 100
-             :medium -> 300
-             _else   -> 100
-           end
-
-    hash = email
-    |> String.trim
-    |> String.downcase
-    |> :erlang.md5
-    |> Base.encode16(case: :lower)
-
-    "https://secure.gravatar.com/avatar/#{hash}.jpg?s=#{size}&d=mm"
-  end
+  defdelegate avatar_url(person), to: SharedView
+  defdelegate avatar_url(person, version), to: SharedView
 end

--- a/lib/fruit_picker_web/views/shared_view.ex
+++ b/lib/fruit_picker_web/views/shared_view.ex
@@ -3,10 +3,12 @@ defmodule FruitPickerWeb.SharedView do
 
   alias FruitPicker.Accounts.{Avatar, Person}
   alias FruitPicker.Accounts.Profile.ProvinceEnum
+
   alias FruitPicker.Activities.{
     Pick,
     PickReport
   }
+
   alias FruitPickerWeb.Endpoint
 
   def province_options do
@@ -68,12 +70,14 @@ defmodule FruitPickerWeb.SharedView do
     case person.role do
       :admin ->
         "admin"
+
       :user ->
         if Enum.any?(friendly_permissions(person)) do
-          Enum.map_join(friendly_permissions(person), ", ", &(&1[:name]))
+          Enum.map_join(friendly_permissions(person), ", ", & &1[:name])
         else
           "volunteer"
         end
+
       :agency ->
         "agency"
     end
@@ -86,6 +90,7 @@ defmodule FruitPickerWeb.SharedView do
   end
 
   def avatar_url(person), do: avatar_url(person, :small)
+
   def avatar_url(person, version) do
     if person.avatar do
       url = avatar_path(person, version)
@@ -140,8 +145,8 @@ defmodule FruitPickerWeb.SharedView do
 
   def report_has_issue?(%PickReport{} = report) do
     report.has_equipment_set_issue or
-    not report.has_fruit_delivered_to_agency or
-    report.has_issues_on_site
+      not report.has_fruit_delivered_to_agency or
+      report.has_issues_on_site
   end
 
   def pick_closest_intersection(%Pick{} = pick) do
@@ -152,18 +157,21 @@ defmodule FruitPickerWeb.SharedView do
     end
   end
 
+  defp gravatar_url(nil, _version), do: "https://www.gravatar.com/avatar"
   defp gravatar_url(email, version) do
-    size = case version do
-             :small  -> 100
-             :medium -> 300
-             _else   -> 100
-           end
+    size =
+      case version do
+        :small -> 100
+        :medium -> 300
+        _else -> 100
+      end
 
-    hash = email
-    |> String.trim
-    |> String.downcase
-    |> :erlang.md5
-    |> Base.encode16(case: :lower)
+    hash =
+      email
+      |> String.trim()
+      |> String.downcase()
+      |> :erlang.md5()
+      |> Base.encode16(case: :lower)
 
     "https://secure.gravatar.com/avatar/#{hash}.jpg?s=#{size}&d=mm"
   end

--- a/priv/repo/migrations/20240709135922_add_deleted_to_people.exs
+++ b/priv/repo/migrations/20240709135922_add_deleted_to_people.exs
@@ -1,0 +1,9 @@
+defmodule FruitPicker.Repo.Migrations.AddDeletedToPeople do
+  use Ecto.Migration
+
+  def change do
+    alter table(:people) do
+      add(:deleted, :boolean, default: false)
+    end
+  end
+end

--- a/priv/repo/migrations/20240717221744_add_deleted_to_properties.exs
+++ b/priv/repo/migrations/20240717221744_add_deleted_to_properties.exs
@@ -1,0 +1,9 @@
+defmodule FruitPicker.Repo.Migrations.AddDeletedToProperties do
+  use Ecto.Migration
+
+  def change do
+    alter table(:properties) do
+      add(:deleted, :boolean, default: false)
+    end
+  end
+end


### PR DESCRIPTION
Closes #114 

We add a `deleted` flag to people which takes them out of all search, and delete the associated `Profile` and any PII.

Note that Agencies and Properties associated with People are not deleted this way.

co-authored with @cthulahoops

